### PR TITLE
Hide photos page from search engines and remove link from home page

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -12,7 +12,6 @@ type Link = {
 
 const links: Link[] = [
   { text: 'Posts', href: '/posts' },
-  { text: 'Photos', href: '/photos' },
   { text: 'Projects', href: '/projects' },
 ];
 

--- a/pages/photos.tsx
+++ b/pages/photos.tsx
@@ -6,6 +6,7 @@ export default function Photos() {
     <div className="w-screen h-screen flex flex-col">
       <Head>
         <title>Photos</title>
+        <meta name="robots" content="noindex" />
         <link rel="canonical" href="https://benknight.me/photos" />
       </Head>
       <Colophon />


### PR DESCRIPTION
Remove the Photos navigation link from the home page while keeping
the /photos route accessible via direct URL. Add robots noindex meta
tag to prevent search engine indexing.

https://claude.ai/code/session_014AJj3fHBznjbucmqkirTcV